### PR TITLE
Fix broken link to v2 repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NB: this repo is for v1 of the fastai library. [https://github.com/fastai/fastai](v2) is the current version. v1 is still supported for bug fixes, but will not receive new features.**
+**NB: this repo is for v1 of the fastai library. https://github.com/fastai/fastai is the current version. v1 is still supported for bug fixes, but will not receive new features.**
 
 [![pypi fastai version](https://img.shields.io/pypi/v/fastai.svg)](https://pypi.python.org/pypi/fastai)
 [![Conda fastai version](https://img.shields.io/conda/v/fastai/fastai.svg)](https://anaconda.org/fastai/fastai)


### PR DESCRIPTION
 Current readme link to v2 is https://github.com/fastai/fastai1/blob/master/v2 which is a 404. Corrected markdown link to github.com/fastai/fastai.

<!-- Feel free to remove check-list items aren't relevant to your change -->
 
 - [X ] Read the [contributing docs](https://github.com/fastai/fastai1/blob/master/CONTRIBUTING.md)
 - [X ] Add details about your PR.
