### PR TITLE
added the support to control train dataloader shuffle

### DIFF
--- a/fastai/basic_data.py
+++ b/fastai/basic_data.py
@@ -113,10 +113,16 @@ class DataBunch():
                val_bs:int=None, num_workers:int=defaults.cpus, dl_tfms:Optional[Collection[Callable]]=None,
                device:torch.device=None, collate_fn:Callable=data_collate, no_check:bool=False, **dl_kwargs)->'DataBunch':
         "Create a `DataBunch` from `train_ds`, `valid_ds` and maybe `test_ds` with a batch size of `bs`. Passes `**dl_kwargs` to `DataLoader()`"
+        #Pass `shuffle` in `**dl_kwargs` to change the train dl to static
+        shuffle = True
+        if 'shuffle' in dl_kwargs:
+            shuffle = dl_kwargs['shuffle']
+            del dl_kwargs['shuffle']
+
         datasets = cls._init_ds(train_ds, valid_ds, test_ds)
         val_bs = ifnone(val_bs, bs)
         dls = [DataLoader(d, b, shuffle=s, drop_last=s, num_workers=num_workers, **dl_kwargs) for d,b,s in
-               zip(datasets, (bs,val_bs,val_bs,val_bs), (True,False,False,False)) if d is not None]
+               zip(datasets, (bs,val_bs,val_bs,val_bs), (shuffle,False,False,False)) if d is not None]
         return cls(*dls, path=path, device=device, dl_tfms=dl_tfms, collate_fn=collate_fn, no_check=no_check)
 
     def __getattr__(self,k:int)->Any: return getattr(self.train_dl, k)


### PR DESCRIPTION
Currently, user can't control the `shuffle` parameter of train dl. with this a user can control the train dl shuffling by passing `shuffle` parameter in `**dl_kwargs`. 
